### PR TITLE
bugfix group sleep

### DIFF
--- a/galaxy/xcms_group/abims_xcms_group.xml
+++ b/galaxy/xcms_group/abims_xcms_group.xml
@@ -17,12 +17,13 @@
         xsetRdataOutput '$xsetRData'
         rplotspdf '$rplotsPdf'
 
-        method $methods.method sleep 0.001
+        method $methods.method 
         #if $methods.method == "density":
             ## minsamp $methods.minsamp
             minfrac $methods.minfrac
             bw $methods.bw
             mzwid $methods.mzwid
+            sleep 0.001
         #if $methods.density_options.option == "show":
             max $methods.density_options.max
         #end if


### PR DESCRIPTION
In group, `sleep` should be only available for `density` :/
Thanks @jfrancoismartin 