### PR TITLE
BUGFIX - encodage issue

### DIFF
--- a/galaxy/macro/macros.xml
+++ b/galaxy/macro/macros.xml
@@ -19,7 +19,7 @@
     </xml>
 
     <token name="@COMMAND_XCMS_SCRIPT@">
-        LANG=C Rscript $__tool_directory__/xcms.r
+        LC_ALL=C Rscript $__tool_directory__/xcms.r
     </token>
 
     <token name="@COMMAND_LOG_EXIT@">

--- a/galaxy/xcms_fillpeaks/README.rst
+++ b/galaxy/xcms_fillpeaks/README.rst
@@ -2,6 +2,10 @@
 Changelog/News
 --------------
 
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 **Version 2.1.0 - 07/02/2017**
 
 - IMPROVEMENT: change the management of the peaklist ids. The main ids remain the same as xcms generated. The export setiings now only add custom names in the variableMetadata tab (namecustom)

--- a/galaxy/xcms_fillpeaks/abims_xcms_fillPeaks.xml
+++ b/galaxy/xcms_fillpeaks/abims_xcms_fillPeaks.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_fillPeaks" name="xcms.fillPeaks" version="2.1.0">
+<tool id="abims_xcms_fillPeaks" name="xcms.fillPeaks" version="2.1.1">
 
     <description>Integrate a sample's signal in regions where peak groups are not represented to create new peaks in missing areas</description>
 
@@ -267,6 +267,10 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
 
 **Version 2.1.0 - 07/02/2017**
 

--- a/galaxy/xcms_fillpeaks/abims_xcms_fillPeaks.xml
+++ b/galaxy/xcms_fillpeaks/abims_xcms_fillPeaks.xml
@@ -226,11 +226,11 @@ xset.fillPeaks.RData : rdata.xcms.fillpeaks format
 
 xset.variableMetadata.tsv : tabular format
 
-    | Table containing information about ions; can be used as one input of **Quality_Metrics** or **Generic_filter* modules.
+    | Table containing information about ions; can be used as one input of **Quality_Metrics** or **Generic_filter** modules.
 
 xset.dataMatrix.tsv : tabular format
 
-    | Table containing ions' intensities; can be used as one input of **Quality_Metrics** or **Generic_filter* modules.
+    | Table containing ions' intensities; can be used as one input of **Quality_Metrics** or **Generic_filter** modules.
 
 ------
 

--- a/galaxy/xcms_group/README.rst
+++ b/galaxy/xcms_group/README.rst
@@ -2,6 +2,10 @@
 Changelog/News
 --------------
 
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 **Version 2.1.0 - 07/02/2017**
 
 - IMPROVEMENT: Add an option to export the peak list at this step without have to wait camara.annotate

--- a/galaxy/xcms_group/abims_xcms_group.xml
+++ b/galaxy/xcms_group/abims_xcms_group.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_group" name="xcms.group" version="2.1.0">
+<tool id="abims_xcms_group" name="xcms.group" version="2.1.1">
 
     <description>Group peaks together across samples using overlapping m/z bins and calculation of smoothed peak distributions in chromatographic time.</description>
 
@@ -17,7 +17,7 @@
         xsetRdataOutput '$xsetRData'
         rplotspdf '$rplotsPdf'
 
-        method $methods.method 
+        method $methods.method
         #if $methods.method == "density":
             ## minsamp $methods.minsamp
             minfrac $methods.minfrac
@@ -413,6 +413,10 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
 
 **Version 2.1.0 - 07/02/2017**
 

--- a/galaxy/xcms_retcor/README.rst
+++ b/galaxy/xcms_retcor/README.rst
@@ -2,6 +2,10 @@
 Changelog/News
 --------------
 
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 **Version 2.1.0 - 03/02/2017**
 
 - IMPROVEMENT: xcms.retcor can deal with merged individual data
@@ -34,4 +38,3 @@ Changelog/News
 - IMPROVEMENT: new datatype/dataset formats (rdata.xcms.raw, rdata.xcms.group, rdata.xcms.retcor ...) will facilitate the sequence of tools and so avoid incompatibility errors.
 
 - IMPROVEMENT: parameter labels have changed to facilitate their reading.
-

--- a/galaxy/xcms_retcor/abims_xcms_retcor.xml
+++ b/galaxy/xcms_retcor/abims_xcms_retcor.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_retcor" name="xcms.retcor" version="2.1.0">
+<tool id="abims_xcms_retcor" name="xcms.retcor" version="2.1.1">
 
     <description>Retention Time Correction using retcor function from xcms R package </description>
 
@@ -318,6 +318,10 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
 
 **Version 2.1.0 - 03/02/2017**
 

--- a/galaxy/xcms_xcmsset/README.rst
+++ b/galaxy/xcms_xcmsset/README.rst
@@ -22,6 +22,10 @@ The [Dynamic Destination Mapping](https://galaxyproject.org/admin/config/jobs/#d
 Changelog/News
 --------------
 
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 **Version 2.1.0 - 22/02/2017**
 
 - NEW: The W4M tools will be able now to take as input a single file. It will allow to submit in parallel several files and merge them afterward using "xcms.xcmsSet Merger" before "xcms.group".

--- a/galaxy/xcms_xcmsset/abims_xcms_xcmsSet.xml
+++ b/galaxy/xcms_xcmsset/abims_xcms_xcmsSet.xml
@@ -593,7 +593,7 @@ Changelog/News
 - TEST: refactoring to feed the new report tool
 
 
-**Version 2.0.2 - 18/01/2016
+**Version 2.0.2 - 18/01/2016**
 
 - BUGFIX: Some zip files were tag as "corrupt" by R. We have changed the extraction mode to deal with thoses cases.
 

--- a/galaxy/xcms_xcmsset/abims_xcms_xcmsSet.xml
+++ b/galaxy/xcms_xcmsset/abims_xcms_xcmsSet.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_xcmsSet" name="xcms.xcmsSet" version="2.1.0">
+<tool id="abims_xcms_xcmsSet" name="xcms.xcmsSet" version="2.1.1">
     <description>Filtration and Peak Identification using xcmsSet function from xcms R package to preprocess LC/MS data for relative quantification and statistical analysis </description>
 
     <macros>
@@ -556,6 +556,10 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.1.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
 
 **Version 2.1.0 - 22/02/2017**
 


### PR DESCRIPTION
This input:

```xml
<?xml version="1.0" encoding="ISO-8859-1"?>
    <parentFile fileName="file:///D:/JPA/Laits-2015-06-10-Exactive (Metabolomique R�cap)/./010615007_QC7_.raw"
```

raises this error:
```
Generating EIC's ..
Error in readChar(filename, 1024) : invalid UTF-8 input in readChar()
Calls: annotatediff ... xcmsSource -> xcmsSource -> .local -> <Anonymous> -> readChar
Execution halted
```