### PR TITLE
Update destinations_input_type.py

### DIFF
--- a/galaxy/xcms_xcmsset/destinations_input_type.py
+++ b/galaxy/xcms_xcmsset/destinations_input_type.py
@@ -15,9 +15,11 @@ def input_type(job):
     log = logging.getLogger(__name__)
     inp_data = dict( [ ( da.name, da.dataset ) for da in job.input_datasets ] )
     inp_data.update( [ ( da.name, da.dataset ) for da in job.input_library_datasets ] )
-    input_extension = inp_data[ "input" ].extension
-    log.debug("The input extension is %s" % input_extension)
-    if input_extension in ["mzxml","mzml","mzdata","netcdf"]:
-        return 'thread1-mem_free10'
-    else: # zip file
-        return 'thread4-men_free10'
+    # for the backward compatibility < 2.1.0 
+    if 'input' in inp_data:
+        input_extension = inp_data[ "input" ].extension
+        log.debug("The input extension is %s" % input_extension)
+        if input_extension in ["mzxml","mzml","mzdata","netcdf"]:
+            return 'thread1-mem_free8'
+    # zip file
+    return 'thread9-mem_free8'


### PR DESCRIPTION
For the backward compatibility < 2.1.0  

It raised this issue 
```
  File "/work/project/w4m/galaxy4metabolomics/galaxy-dist/lib/galaxy/jobs/rules/destinations_input_type.py", line 18, in input_type
    if 'input' in inp_data:
KeyError: 'input'
```

Because, input appear from 2.1.0, before:
```xml
<conditional name="inputs">
            <param name="input" type="select" label="Choose your inputs method" >
                <option value="zip_file" selected="true">Zip file from your history containing your chromatograms</option>
                <option value="lib" >Library directory name</option>
            </param>
```