### PR TITLE
Update xcmsSet to be able to run files with MS1 and MS2

### DIFF
--- a/tools/xcms_xcmsset/xcms_xcmsSet.r
+++ b/tools/xcms_xcmsset/xcms_xcmsSet.r
@@ -84,7 +84,6 @@ if (exists("filterAcquisitionNumParam"))  raw_data <- filterAcquisitionNum(raw_d
 if (exists("filterRtParam")) raw_data <- filterRt(raw_data, filterRtParam)
 if (exists("filterMzParam")) raw_data <- filterMz(raw_data, filterMzParam)
 raw_data <- filterMsLevel(raw_data,msLevel=1)
-print(raw_data)
 
 cat("\t\t\tChromatographic peak detection\n")
 # clear the arguement list to remove unexpected key/value as singlefile_galaxyPath or method ...
@@ -92,7 +91,7 @@ args <- args[names(args) %in% slotNames(do.call(paste0(method,"Param"), list()))
 
 findChromPeaksParam <- do.call(paste0(method,"Param"), args)
 print(findChromPeaksParam)
-xdata <- findChromPeaks(raw_data, param=findChromPeaksParam, msLevel=1)
+xdata <- findChromPeaks(raw_data, param=findChromPeaksParam)
 
 # Check if there are no peaks
 if (nrow(chromPeaks(xdata)) == 0) stop("No peaks were detected. You should review your settings")

--- a/tools/xcms_xcmsset/xcms_xcmsSet.r
+++ b/tools/xcms_xcmsset/xcms_xcmsSet.r
@@ -83,6 +83,8 @@ cat("\t\t\tApply filter[s] (if asked)\n")
 if (exists("filterAcquisitionNumParam"))  raw_data <- filterAcquisitionNum(raw_data, filterAcquisitionNumParam[1]:filterAcquisitionNumParam[2])
 if (exists("filterRtParam")) raw_data <- filterRt(raw_data, filterRtParam)
 if (exists("filterMzParam")) raw_data <- filterMz(raw_data, filterMzParam)
+raw_data <- filterMsLevel(raw_data,msLevel=1)
+print(raw_data)
 
 cat("\t\t\tChromatographic peak detection\n")
 # clear the arguement list to remove unexpected key/value as singlefile_galaxyPath or method ...
@@ -90,7 +92,7 @@ args <- args[names(args) %in% slotNames(do.call(paste0(method,"Param"), list()))
 
 findChromPeaksParam <- do.call(paste0(method,"Param"), args)
 print(findChromPeaksParam)
-xdata <- findChromPeaks(raw_data, param=findChromPeaksParam)
+xdata <- findChromPeaks(raw_data, param=findChromPeaksParam, msLevel=1)
 
 # Check if there are no peaks
 if (nrow(chromPeaks(xdata)) == 0) stop("No peaks were detected. You should review your settings")

--- a/tools/xcms_xcmsset/xcms_xcmsSet.r
+++ b/tools/xcms_xcmsset/xcms_xcmsSet.r
@@ -83,7 +83,10 @@ cat("\t\t\tApply filter[s] (if asked)\n")
 if (exists("filterAcquisitionNumParam"))  raw_data <- filterAcquisitionNum(raw_data, filterAcquisitionNumParam[1]:filterAcquisitionNumParam[2])
 if (exists("filterRtParam")) raw_data <- filterRt(raw_data, filterRtParam)
 if (exists("filterMzParam")) raw_data <- filterMz(raw_data, filterMzParam)
-raw_data <- filterMsLevel(raw_data,msLevel=1)
+#Apply this filter only if file contain MS and MSn
+if(length(unique(msLevel(raw_data)))!= 1){
+	raw_data <- filterMsLevel(raw_data,msLevel=1)
+}
 
 cat("\t\t\tChromatographic peak detection\n")
 # clear the arguement list to remove unexpected key/value as singlefile_galaxyPath or method ...


### PR DESCRIPTION
Just adding a filter to keep only MS1 peaks from files containing MS1 and also MSn datas.
The `xdata <- findChromPeaks(raw_data, param=findChromPeaksParam, msLevel=1)` seems not to be an obligation with `msLevel=1`