### PR TITLE
all - disable chromtogram for all tool except plotChromatogram

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ install:
 
 script:
   - planemo lint ${TRAVIS_BUILD_DIR}/${TESTFOLDER}
-  - planemo test --conda_ensure_channels bioconda,workflow4metabolomics,conda-forge,default --galaxy_branch release_18.05 --no_cache_galaxy ${TRAVIS_BUILD_DIR}/${TESTFOLDER}
+  # --conda_ensure_channels bioconda,workflow4metabolomics,conda-forge,default
+  - planemo test  --galaxy_branch release_18.05 --no_cache_galaxy ${TRAVIS_BUILD_DIR}/${TESTFOLDER}

--- a/tools/macro/macros_msnbase.xml
+++ b/tools/macro/macros_msnbase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-    <token name="@WRAPPER_VERSION@">2.4.0</token>
+    <token name="@WRAPPER_VERSION@">2.8.2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@WRAPPER_VERSION@">bioconductor-msnbase</requirement>

--- a/tools/msnbase_readmsdata/README.rst
+++ b/tools/msnbase_readmsdata/README.rst
@@ -1,0 +1,11 @@
+
+Changelog/News
+--------------
+
+**Version 2.8.2.0 - 08/04/2019**
+
+- UPGRADE: upgrade the MSnbase version from 2.4.0 to 2.8.2 (see MSnbase News_). Almost all the new features may not concern our usage of MSnbase.
+
+**Version 2.4.0.0 - 29/03/2018**
+
+- NEW: a new dedicated tool to read the raw data. This function was previously included in xcms.findChromPeaks. This way, you will now be able to display TICs and BPCs before xcms.findChromPeaks.

--- a/tools/msnbase_readmsdata/msnbase_readmsdata.r
+++ b/tools/msnbase_readmsdata/msnbase_readmsdata.r
@@ -91,7 +91,7 @@ print(raw_data@phenoData@data)
 cat("\n\n")
 
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save <- c("raw_data", "zipfile", "singlefile", "md5sumList", "sampleNamesList", "chromTIC", "chromBPI")
+objects2save <- c("raw_data", "zipfile", "singlefile", "md5sumList", "sampleNamesList") #, "chromTIC", "chromBPI")
 save(list=objects2save[objects2save %in% ls()], file="readmsdata.RData")
 
 

--- a/tools/msnbase_readmsdata/msnbase_readmsdata.xml
+++ b/tools/msnbase_readmsdata/msnbase_readmsdata.xml
@@ -230,6 +230,11 @@ sampleMetadata.tsv (only when a zip is used)
 Changelog/News
 --------------
 
+.. _News: https://bioconductor.org/packages/release/bioc/news/MSnbase/NEWS
+
+**Version 2.8.2.0 - 08/04/2019**
+
+- UPGRADE: upgrade the MSnbase version from 2.4.0 to 2.8.2 (see MSnbase News_). Almost all the new features may not concern our usage of MSnbase.
 
 **Version 2.4.0.0 - 29/03/2018**
 

--- a/tools/msnbase_readmsdata/msnbase_readmsdata.xml
+++ b/tools/msnbase_readmsdata/msnbase_readmsdata.xml
@@ -42,7 +42,7 @@
                 <has_text text="rowNames: faahKO_reduce/KO/ko15.CDF faahKO_reduce/KO/ko16.CDF" />
                 <has_text text="faahKO_reduce/WT/wt15.CDF faahKO_reduce/WT/wt16.CDF" />
                 <has_text text="featureNames: F1.S0001 F1.S0002 ... F4.S1278 (5112 total)" />
-                <has_text text="fvarLabels: fileIdx spIdx ... spectrum (27 total)" />
+                <has_text text="fvarLabels: fileIdx spIdx ... spectrum (28 total)" />
                 <has_text text="faahKO_reduce/KO/ko15.CDF        ko15           KO" />
                 <has_text text="faahKO_reduce/KO/ko16.CDF        ko16           KO" />
                 <has_text text="faahKO_reduce/WT/wt15.CDF        wt15           WT" />
@@ -56,7 +56,7 @@
                 <has_text text="rowNames: ./ko15.CDF" />
                 <has_text text="ko15.CDF" />
                 <has_text text="featureNames: F1.S0001 F1.S0002 ... F1.S1278 (1278 total)" />
-                <has_text text="fvarLabels: fileIdx spIdx ... spectrum (27 total)" />
+                <has_text text="fvarLabels: fileIdx spIdx ... spectrum (28 total)" />
                 <has_text text="./ko15.CDF        ko15            ." />
             </assert_stdout>
         </test>

--- a/tools/xcms_fillpeaks/xcms_fillpeaks.r
+++ b/tools/xcms_fillpeaks/xcms_fillpeaks.r
@@ -103,7 +103,7 @@ print(xset)
 cat("\n\n")
 
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList", "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
+objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList") #, "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
 save(list=objects2save[objects2save %in% ls()], file="fillpeaks.RData")
 
 cat("\n\n")

--- a/tools/xcms_group/xcms_group.r
+++ b/tools/xcms_group/xcms_group.r
@@ -104,7 +104,7 @@ print(xset)
 cat("\n\n")
 
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList", "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
+objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList") #, "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
 save(list=objects2save[objects2save %in% ls()], file="group.RData")
 
 cat("\n\n")

--- a/tools/xcms_merge/xcms_merge.r
+++ b/tools/xcms_merge/xcms_merge.r
@@ -40,5 +40,5 @@ cat("\n\n")
 
 cat("\tSAVE RData\n")
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save <- c("xdata", "zipfile", "singlefile", "md5sumList", "sampleNamesList", "chromTIC", "chromBPI")
+objects2save <- c("xdata", "zipfile", "singlefile", "md5sumList", "sampleNamesList") #, "chromTIC", "chromBPI")
 save(list=objects2save[objects2save %in% ls()], file="merged.RData")

--- a/tools/xcms_retcor/xcms_retcor.r
+++ b/tools/xcms_retcor/xcms_retcor.r
@@ -92,7 +92,7 @@ print(xset)
 cat("\n\n")
 
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList", "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
+objects2save = c("xdata","zipfile","singlefile","md5sumList","sampleNamesList") #, "chromTIC", "chromBPI", "chromTIC_adjusted", "chromBPI_adjusted")
 save(list=objects2save[objects2save %in% ls()], file="retcor.RData")
 
 cat("\n\n")

--- a/tools/xcms_summary/abims_xcms_summary.xml
+++ b/tools/xcms_summary/abims_xcms_summary.xml
@@ -8,8 +8,7 @@
     </macros>
 
     <requirements>
-        <requirement type="package" version="3.0.0">bioconductor-xcms</requirement>
-        <requirement type="package" version="1.32.0">bioconductor-camera</requirement>
+        <requirement type="package" version="1.38.1">bioconductor-camera</requirement>
         <requirement type="package" version="1.1_4">r-batch</requirement>
     </requirements>
 

--- a/tools/xcms_summary/test-data/faahKO-single.xset.merged.group.retcor.group.fillpeaks.summary.html
+++ b/tools/xcms_summary/test-data/faahKO-single.xset.merged.group.retcor.group.fillpeaks.summary.html
@@ -25,58 +25,58 @@ ul li { margin-bottom:10px; }
 <div><table>
 <tr><th>timestamp<sup>***</sup></th><th>function</th><th>argument</th><th>value</th></tr>
 <tr><td>Wed Feb  7 11:15:25 2018</td><td>Peak detection</td><td colspan='2'><pre>
-Object of class:  CentWaveParam 
+Object of class:  CentWaveParam
 Parameters:
- ppm: 25 
- peakwidth: 20, 50 
- snthresh: 10 
- prefilter: 3, 100 
- mzCenterFun: wMean 
- integrate: 1 
- mzdiff: -0.001 
- fitgauss: FALSE 
- noise: 0 
- verboseColumns: FALSE 
- roiList length: 0 
- firstBaselineCheck TRUE 
- roiScales length: 0 
+ ppm: 25
+ peakwidth: 20, 50
+ snthresh: 10
+ prefilter: 3, 100
+ mzCenterFun: wMean
+ integrate: 1
+ mzdiff: -0.001
+ fitgauss: FALSE
+ noise: 0
+ verboseColumns: FALSE
+ roiList length: 0
+ firstBaselineCheck TRUE
+ roiScales length: 0
 </pre></td></tr>
 <tr><td>Mon Feb 12 15:31:11 2018</td><td>Peak grouping</td><td colspan='2'><pre>
-Object of class:  PeakDensityParam 
+Object of class:  PeakDensityParam
 Parameters:
- sampleGroups: character of length 4 
- bw: 30 
- minFraction: 0.8 
- minSamples: 1 
- binSize: 0.25 
- maxFeatures: 50 
+ sampleGroups: character of length 4
+ bw: 30
+ minFraction: 0.8
+ minSamples: 1
+ binSize: 0.25
+ maxFeatures: 50
 </pre></td></tr>
 <tr><td>Mon Feb 12 15:31:19 2018</td><td>Retention time correction</td><td colspan='2'><pre>
-Object of class:  PeakGroupsParam 
+Object of class:  PeakGroupsParam
 Parameters:
- minFraction: 0.85 
- extraPeaks: 1 
- smooth: loess 
- span: 0.2 
- family: gaussian 
- number of peak groups: 125 
+ minFraction: 0.85
+ extraPeaks: 1
+ smooth: loess
+ span: 0.2
+ family: gaussian
+ number of peak groups: 125
 </pre></td></tr>
 <tr><td>Mon Feb 12 15:31:27 2018</td><td>Peak grouping</td><td colspan='2'><pre>
-Object of class:  PeakDensityParam 
+Object of class:  PeakDensityParam
 Parameters:
- sampleGroups: character of length 4 
- bw: 20 
- minFraction: 0.4 
- minSamples: 1 
- binSize: 0.25 
- maxFeatures: 50 
+ sampleGroups: character of length 4
+ bw: 20
+ minFraction: 0.4
+ minSamples: 1
+ binSize: 0.25
+ maxFeatures: 50
 </pre></td></tr>
 <tr><td>Wed Feb 14 09:55:13 2018</td><td>Missing peak filling</td><td colspan='2'><pre>
-Object of class:  FillChromPeaksParam 
+Object of class:  FillChromPeaksParam
 Parameters:
- expandMz: 0 
- expandRt: 0 
- ppm: 0 
+ expandMz: 0
+ expandRt: 0
+ ppm: 0
 </pre></td></tr>
 </table>
 <br/><sup>***</sup>timestamp format: DD MM dd hh:mm:ss YYYY or yymmdd-hh:mm:ss
@@ -84,14 +84,14 @@ Parameters:
 <h2>Informations about the XCMSnExp object:</h2>
 <div><pre>
 MSn experiment data ("XCMSnExp")
-Object size in memory: 1.36 Mb
+Object size in memory: 1.41 Mb
 - - - Spectra data - - -
- MS level(s): 1 
- Number of spectra: 5112 
+ MS level(s): 1
+ Number of spectra: 5112
  MSn retention times: 41:33 - 75:0 minutes
 - - - Processing information - - -
-Concatenated [Thu Feb  8 15:36:09 2018] 
- MSnbase version: 2.4.2 
+Concatenated [Thu Feb  8 15:36:09 2018]
+ MSnbase version: 2.4.2
 - - - Meta data  - - -
 phenoData
   rowNames: ./ko15.CDF ./ko16.CDF ./wt15.CDF ./wt16.CDF
@@ -108,13 +108,13 @@ featureData
 experimentData: use 'experimentData(object)'
 - - - xcms preprocessing - - -
 Chromatographic peak detection:
- method: centWave 
+ method: centWave
  15230 peaks identified in 4 samples.
  On average 3808 chromatographic peaks per sample.
 Alignment/retention time adjustment:
- method: peak groups 
+ method: peak groups
 Correspondence:
- method: chromatographic peak density 
+ method: chromatographic peak density
  6332 features identified.
  Median mz range of features: 0
  Median rt range of features: 0
@@ -127,16 +127,16 @@ An "xcmsSet" object with 4 samples
 Time range: 2499.4-4473.6 seconds (41.7-74.6 minutes)
 Mass range: 200.1-600 m/z
 Peaks: 15230 (about 3808 per sample)
-Peak Groups: 6332 
-Sample classes: KO, WT 
+Peak Groups: 6332
+Sample classes: KO, WT
 
 Feature detection:
  o Peak picking performed on MS1.
- o Scan range limited to  1 - 1278 
+ o Scan range limited to  1 - 1278
 Profile settings: method = bin
                   step = 0.1
 
-Memory usage: 2.98 MB
+Memory usage: 3.11 MB
 </pre></div>
 <h2>Citations:</h2>
 <div><ul>

--- a/tools/xcms_xcmsset/xcms_xcmsSet.r
+++ b/tools/xcms_xcmsset/xcms_xcmsSet.r
@@ -124,7 +124,7 @@ print(xset)
 cat("\n\n")
 
 #saving R data in .Rdata file to save the variables used in the present tool
-objects2save <- c("xdata", "zipfile", "singlefile", "md5sumList", "sampleNamesList", "chromTIC", "chromBPI")
+objects2save <- c("xdata", "zipfile", "singlefile", "md5sumList", "sampleNamesList") #, "chromTIC", "chromBPI")
 save(list=objects2save[objects2save %in% ls()], file="xcmsSet.RData")
 
 


### PR DESCRIPTION
According to @sneumann, chrom* object can be really huge: https://github.com/sneumann/xcms/issues/358#issuecomment-472628806

I'm disabling the chrom generation in all the tool (except plotChromatogram).
Originally, I did that to save time during the visualisation display in the context of the @RomainDallet RShiny app. We need to think again about that. Maybe require the use of plotChromatogram before the visualisation ?

(ping @melpetera )