### PR TITLE
fix for file system paths

### DIFF
--- a/tools/scripts/lib.r
+++ b/tools/scripts/lib.r
@@ -333,7 +333,7 @@ checkFilesCompatibilityWithXcms <- function(directory) {
     files[exists] <- sub("//","/",files[exists])
 
     # WHAT IS ON THE FILESYSTEM
-    filesystem_filepaths <- system(paste0("find \"$PWD/",directory,"\" -not -name '\\.*' -not -path '*conda-env*' -type f -name \"*\""), intern=T)
+    filesystem_filepaths <- system(paste0("find \"",getwd(),"/",directory,"\" -not -name '\\.*' -not -path '*conda-env*' -type f -name \"*\""), intern=T)
     filesystem_filepaths <- filesystem_filepaths[grep(filepattern, filesystem_filepaths, perl=T)]
 
     # COMPARISON


### PR DESCRIPTION
problem on our file system there is a link from `/work` to `/gpfs1/work/`. This path contains Galaxy's jobs_directory. In the function `checkFilesCompatibilityWithXcms` the variable

- `files` gets `"/gpfs1/work/.../jobs_directory/025/25500/working/Blanc04.mzXML"` and
- `filesystem_filepaths` gets `"/work/.../jobs_directory/025/25500/working/./Blanc04.mzXML"`

which is unequal and makes the whole function fail.

Besides: I don't understand two points:
- why the function uses absolute paths (could be simplified quite a bit)
- is the aim of the function to check if `list.files` gives the same
  files as the bash `find`? Why shouldn't it